### PR TITLE
oneOf

### DIFF
--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -24,6 +24,9 @@ sep1 s p = (:) <$> p <*> many (s *> p)
 sep :: Parser sep -> Parser a -> Parser [a]
 sep s p = s `sep1` p <|> pure []
 
+oneOf :: (Foldable t, Alternative f) => t a -> f a
+oneOf = foldl (flip ((<|>) . pure)) empty
+
 
 -- Types
 


### PR DESCRIPTION
Adds a `oneOf` function selecting one of a `Foldable` of `Alternative`s.  It’s included here for parsing but generalizes nicely.
