### PR TITLE
Generalize over tokens

### DIFF
--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -43,10 +43,10 @@ parse :: Parser t a -> String -> [a]
 parse p = parseNull . foldl deriv (compact p)
 
 
-commaSep1 :: Combinator v t a -> Combinator v t [a]
+commaSep1 :: Combinator v Char a -> Combinator v Char [a]
 commaSep1 = sep1 (char ',')
 
-commaSep :: Combinator v t a -> Combinator v t [a]
+commaSep :: Combinator v Char a -> Combinator v Char [a]
 commaSep = sep (char ',')
 
 sep1 :: Combinator v t sep -> Combinator v t a -> Combinator v t [a]

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -39,7 +39,7 @@ import Data.Monoid hiding (Alt)
 
 -- API
 
-parse :: Parser Char a -> String -> [a]
+parse :: Parser t a -> [t] -> [a]
 parse p = parseNull . foldl deriv (compact p)
 
 

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -104,7 +104,7 @@ data ParserF t f a where
   Rep :: f a -> ParserF t f [a]
   Map :: (a -> b) -> f a -> ParserF t f b
   Bnd :: f a -> (a -> f b) -> ParserF t f b
-  Tok :: Char -> ParserF Char f Char
+  Tok :: t -> ParserF t f t
   Uni :: GeneralCategory -> ParserF t f Char
   Ret :: [a] -> ParserF t f a
   Nul :: ParserF t f a

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -104,7 +104,7 @@ data ParserF t f a where
   Rep :: f a -> ParserF t f [a]
   Map :: (a -> b) -> f a -> ParserF t f b
   Bnd :: f a -> (a -> f b) -> ParserF t f b
-  Tok :: Char -> ParserF t f Char
+  Tok :: Char -> ParserF Char f Char
   Uni :: GeneralCategory -> ParserF t f Char
   Ret :: [a] -> ParserF t f a
   Nul :: ParserF t f a

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -114,6 +114,10 @@ data ParserF t f a where
 type Parser t = Graph (ParserF t)
 type Combinator v t = Rec (ParserF t) v
 
+data Predicate t where
+  Equal :: Eq t => t -> Predicate t
+  Category :: GeneralCategory -> Predicate Char
+
 
 -- Algorithm
 

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -105,7 +105,7 @@ data ParserF t f a where
   Map :: (a -> b) -> f a -> ParserF t f b
   Bnd :: f a -> (a -> f b) -> ParserF t f b
   Tok :: t -> ParserF t f t
-  Uni :: GeneralCategory -> ParserF t f Char
+  Uni :: GeneralCategory -> ParserF Char f Char
   Ret :: [a] -> ParserF t f a
   Nul :: ParserF t f a
   Lab :: f a -> String -> ParserF t f a

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -39,7 +39,7 @@ import Data.Monoid hiding (Alt)
 
 -- API
 
-parse :: Parser t a -> String -> [a]
+parse :: Parser Char a -> String -> [a]
 parse p = parseNull . foldl deriv (compact p)
 
 

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -273,7 +273,7 @@ instance Monad (Graph (ParserF t)) where
   return = pure
   Graph p >>= f = Graph (p >>= unGraph . f)
 
-instance HEqF (ParserF t)
+instance Eq t => HEqF (ParserF t)
   where heqF eq a b = case (a, b) of
           (Cat a1 b1, Cat a2 b2) -> eq a1 a2 && eq b1 b2
           (Alt a1 b1, Alt a2 b2) -> eq a1 a2 && eq b1 b2
@@ -286,7 +286,7 @@ instance HEqF (ParserF t)
           (Lab p1 s1, Lab p2 s2) -> s1 == s2 && eq p1 p2
           _ -> False
 
-instance HShowF (ParserF t)
+instance Show t => HShowF (ParserF t)
   where hshowsPrecF showsPrec n p = case p of
           Cat a b -> showParen (n > 4) $ showsPrec 4 a . showString " `cat` " . showsPrec 5 b
           Alt a b -> showParen (n > 3) $ showsPrec 3 a . showString " <|> " . showsPrec 4 b

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -217,6 +217,12 @@ newtype K a b = K { getK :: a }
   deriving (Eq, Functor, Ord, Show)
 
 
+satisfies :: t -> Predicate t -> Bool
+satisfies t p = case p of
+  Equal t' -> t == t'
+  Category c -> generalCategory t == c
+
+
 -- Instances
 
 instance HFunctor (ParserF t) where

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -39,7 +39,7 @@ import Data.Monoid hiding (Alt)
 
 -- API
 
-parse :: Parser t a -> [t] -> [a]
+parse :: Foldable f => Parser t a -> f t -> [a]
 parse p = parseNull . foldl deriv (compact p)
 
 

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -117,14 +117,14 @@ type Combinator v t = Rec (ParserF t) v
 
 -- Algorithm
 
-deriv :: Parser t a -> Char -> Parser t a
+deriv :: Parser Char a -> Char -> Parser Char a
 deriv g c = Graph (deriv' (unGraph g))
-  where deriv' :: Combinator (Combinator v t) t a -> Combinator v t a
+  where deriv' :: Combinator (Combinator v Char) Char a -> Combinator v Char a
         deriv' rc = case rc of
           Var v -> v
           Rec (Mu g) -> deriv'' (g (pjoin (Graph.mu g)))
           Rec (In r) -> deriv'' r
-        deriv'' :: ParserF t (Combinator (Combinator v t) t) a -> Combinator v t a
+        deriv'' :: ParserF Char (Combinator (Combinator v Char) Char) a -> Combinator v Char a
         deriv'' p = case p of
           Cat a b -> deriv' a `cat` pjoin b <|> delta (pjoin a) `cat` deriv' b
           Alt a b -> deriv' a <|> deriv' b

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -283,7 +283,7 @@ instance Monad (Graph (ParserF t)) where
   return = pure
   Graph p >>= f = Graph (p >>= unGraph . f)
 
-instance Eq t => HEqF (ParserF t)
+instance HEqF (ParserF t)
   where heqF eq a b = case (a, b) of
           (Cat a1 b1, Cat a2 b2) -> eq a1 a2 && eq b1 b2
           (Alt a1 b1, Alt a2 b2) -> eq a1 a2 && eq b1 b2

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -328,3 +328,8 @@ instance Eq (Predicate t) where
   Equal a == Equal b = a == b
   Category a == Category b = a == b
   _ == _ = False
+
+instance Show t => Show (Predicate t) where
+  showsPrec n p = case p of
+    Equal t -> showParen True $ showString "== " . showsPrec 4 t
+    Category c -> showParen (n >= 9) $ showString "(== " . showsPrec 4 c . showString ") . generalCategory"

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -323,3 +323,8 @@ instance Monoid a => Alternative (K a)
 instance Monoid a => Monad (K a)
   where return = pure
         K a >>= _ = K a
+
+instance Eq (Predicate t) where
+  Equal a == Equal b = a == b
+  Category a == Category b = a == b
+  _ == _ = False

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, GADTs, MultiParamTypeClasses, RankNTypes #-}
+{-# LANGUAGE DeriveFunctor, FlexibleInstances, GADTs, MultiParamTypeClasses, RankNTypes, ScopedTypeVariables #-}
 module Derivative.Parser
 ( cat
 , commaSep
@@ -120,14 +120,14 @@ data Predicate t where
 
 -- Algorithm
 
-deriv :: Parser Char a -> Char -> Parser Char a
+deriv :: forall a t. Parser t a -> t -> Parser t a
 deriv g c = Graph (deriv' (unGraph g))
-  where deriv' :: Combinator (Combinator v Char) Char a -> Combinator v Char a
+  where deriv' :: forall a v. Combinator (Combinator v t) t a -> Combinator v t a
         deriv' rc = case rc of
           Var v -> v
           Rec (Mu g) -> deriv'' (g (pjoin (Graph.mu g)))
           Rec (In r) -> deriv'' r
-        deriv'' :: ParserF Char (Combinator (Combinator v Char) Char) a -> Combinator v Char a
+        deriv'' :: forall a v. ParserF t (Combinator (Combinator v t) t) a -> Combinator v t a
         deriv'' p = case p of
           Cat a b -> deriv' a `cat` pjoin b <|> delta (pjoin a) `cat` deriv' b
           Alt a b -> deriv' a <|> deriv' b

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -29,6 +29,7 @@ module Derivative.Parser
 import Control.Applicative
 import Data.Bifunctor (first)
 import Data.Char
+import Data.Foldable (foldl')
 import Data.Higher.Foldable
 import Data.Higher.Functor
 import Data.Higher.Functor.Eq
@@ -40,7 +41,7 @@ import Data.Monoid hiding (Alt)
 -- API
 
 parse :: Foldable f => Parser t a -> f t -> [a]
-parse p = parseNull . foldl deriv (compact p)
+parse p = parseNull . foldl' deriv (compact p)
 
 
 commaSep1 :: Combinator v Char a -> Combinator v Char [a]

--- a/src/Derivative/Parser/Char.hs
+++ b/src/Derivative/Parser/Char.hs
@@ -16,35 +16,35 @@ import Control.Applicative
 import Data.Char
 import Derivative.Parser
 
-space :: Combinator v Char
+space :: Combinator v Char Char
 space = oneOf (category <$> [Space .. ParagraphSeparator]) <|> oneOf (char <$> "\t\n\r\f\v")
 
-upper :: Combinator v Char
+upper :: Combinator v Char Char
 upper = category UppercaseLetter
 
-lower :: Combinator v Char
+lower :: Combinator v Char Char
 lower = category LowercaseLetter
 
-alphaNum :: Combinator v Char
+alphaNum :: Combinator v Char Char
 alphaNum = letter <|> oneOf (category <$> [DecimalNumber .. OtherNumber])
 
-letter :: Combinator v Char
+letter :: Combinator v Char Char
 letter = oneOf (category <$> [UppercaseLetter .. OtherLetter])
 
-digit :: Combinator v Char
+digit :: Combinator v Char Char
 digit = oneOf (char <$> ['0'..'9'])
 
-octDigit :: Combinator v Char
+octDigit :: Combinator v Char Char
 octDigit = oneOf (char <$> ['0'..'7'])
 
-hexDigit :: Combinator v Char
+hexDigit :: Combinator v Char Char
 hexDigit = digit <|> oneOf (char <$> ['a'..'f']) <|> oneOf (char <$> ['A'..'F'])
 
-newline :: Combinator v Char
+newline :: Combinator v Char Char
 newline = char '\n'
 
-crlf :: Combinator v Char
+crlf :: Combinator v Char Char
 crlf = char '\r' *> newline
 
-endOfLine :: Combinator v Char
+endOfLine :: Combinator v Char Char
 endOfLine = newline <|> crlf

--- a/test/Derivative/Parser/Spec.hs
+++ b/test/Derivative/Parser/Spec.hs
@@ -163,13 +163,13 @@ spec = do
       \ u y -> parseNull ((getBlind u :: Parser Char (Char -> Char)) <*> pure y) `shouldBe` parseNull (pure ($ y) <*> getBlind u)
 
     prop "obeys the fmap identity" $
-      \ f x -> parseNull (pure (getBlind f :: Char -> Char) <*> x) `shouldBe` parseNull (fmap (getBlind f) x)
+      \ f x -> parseNull ((pure (getBlind f) :: Parser Char (Char -> Char)) <*> x) `shouldBe` parseNull (fmap (getBlind f) x)
 
     prop "obeys the return identity" $
       \ f -> pure (getBlind f :: Char -> Char) `shouldBe` (return (getBlind f :: Char -> Char) :: Parser Char (Char -> Char))
 
     prop "obeys the ap identity" $
-      \ f x -> parseNull (pure (getBlind f :: Char -> Char) <*> x) `shouldBe` parseNull (pure (getBlind f :: Char -> Char) `ap` x)
+      \ f x -> parseNull ((pure (getBlind f) :: Parser Char (Char -> Char)) <*> x) `shouldBe` parseNull (pure (getBlind f :: Char -> Char) `ap` x)
 
     prop "obeys the left-discarding identity" $
       \ u v -> parseNull (u *> v) `shouldBe` parseNull (pure (const id) <*> (u :: Parser Char Char) <*> (v :: Parser Char Char))

--- a/test/Derivative/Parser/Spec.hs
+++ b/test/Derivative/Parser/Spec.hs
@@ -268,7 +268,7 @@ spec = do
 
 -- Grammar
 
-cyclic :: Parser t ()
+cyclic :: Parser Char ()
 cyclic = parser $ mu $ \ v -> v `label` "cyclic"
 
 varName :: Parser Char String

--- a/test/Derivative/Parser/Spec.hs
+++ b/test/Derivative/Parser/Spec.hs
@@ -98,14 +98,14 @@ spec = do
 
     describe "pure" $ do
       prop "has the null derivative" $
-        \ a c -> pure (a :: Char) `deriv` c `shouldBe` empty
+        \ a c -> pure (a :: Char) `deriv` (c :: Char) `shouldBe` empty
 
     it "terminates on cyclic grammars" $
       compact (lam `deriv` 'x') `shouldNotBe` empty
 
     describe "ret" $ do
       prop "annihilates" $
-        \ a c -> parser (ret (a :: String)) `deriv` c `shouldBe` empty
+        \ a c -> parser (ret (a :: String)) `deriv` (c :: Char) `shouldBe` empty
 
     describe "label" $ do
       prop "distributivity" $


### PR DESCRIPTION
Generalizes parsers over the token type.

This entailed the definition of a `Sat` constructor which generalizes both the `Chr` and `Uni` constructors with the assistance of a `Predicate` type. We currently retain the same public API for constructing parsers of characters and categories.
