### PR TITLE
Minor code linting and fixed a bug in the benchmark.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .stack-work
 tags
+dist-newstyle

--- a/space/Main.hs
+++ b/space/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import Control.Applicative
 import Control.DeepSeq
 import Derivative.Parser
-import Weigh
+import Weigh hiding (wgroup)
 
 main :: IO ()
 main = mainWith $ do

--- a/src/Data/Functor/K.hs
+++ b/src/Data/Functor/K.hs
@@ -2,7 +2,6 @@
 module Data.Functor.K (K(..)) where
 
 import Control.Applicative
-import Data.Monoid
 
 newtype K a b = K { getK :: a }
   deriving (Eq, Functor, Ord, Show)

--- a/src/Data/Higher/Functor/Recursive.hs
+++ b/src/Data/Higher/Functor/Recursive.hs
@@ -2,8 +2,9 @@
 module Data.Higher.Functor.Recursive where
 
 import Data.Higher.Functor
+import Data.Kind (Type)
 
-type family Base (t :: k -> *) :: (k -> *) -> k -> *
+type family Base (t :: k -> Type) :: (k -> Type) -> k -> Type
 
 class HFunctor (Base t) => HCorecursive t where
   hembed :: Base t t a -> t a

--- a/src/Data/Higher/Graph.hs
+++ b/src/Data/Higher/Graph.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, PolyKinds, RankNTypes, ScopedTypeVariables, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE FlexibleInstances, RankNTypes, ScopedTypeVariables, TypeFamilies, TypeOperators, TypeInType #-}
 module Data.Higher.Graph
 ( Rec(..)
 , RecF(..)

--- a/src/Data/Higher/Graph.hs
+++ b/src/Data/Higher/Graph.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, InstanceSigs, PolyKinds, RankNTypes, ScopedTypeVariables, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE FlexibleInstances, PolyKinds, RankNTypes, ScopedTypeVariables, TypeFamilies, TypeOperators #-}
 module Data.Higher.Graph
 ( Rec(..)
 , RecF(..)

--- a/src/Data/Pattern.hs
+++ b/src/Data/Pattern.hs
@@ -244,7 +244,7 @@ instance Functor (Fix (PatternF t))
 
 instance Applicative (Fix (PatternF t))
   where pure = hembed . Ret . pure
-        (<*>) = (((fmap (uncurry ($))) . hembed) .) . Cat
+        (<*>) = ((fmap (uncurry ($)) . hembed) .) . Cat
 
 instance Alternative (Fix (PatternF t))
   where empty = hembed Nul

--- a/src/Derivative/Parser.hs
+++ b/src/Derivative/Parser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GADTs, RankNTypes, ScopedTypeVariables, TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances, GADTs, RankNTypes, ScopedTypeVariables #-}
 module Derivative.Parser
 ( compact
 , deriv
@@ -53,7 +53,7 @@ type Combinator t = Rec (PatternF t)
 
 deriv :: forall a t. Parser t a -> t -> Parser t a
 deriv g c = Graph (deriv' (combinator g))
-  where deriv' :: forall a v. Combinator t (Combinator t v) a -> Combinator t v a
+  where deriv' :: forall a v. Combinator t (Combinator t v) a -> Combinator t v a
         deriv' rc = case rc of
           Var v -> v
           Rec (Mu g) -> deriv'' (g (pjoin (Graph.mu g)))


### PR DESCRIPTION
Although this can be built successfully on GHC 8.10.7. I still couldn't build this code on GHC 9 due to this reason and I wish you can enlighten me :)

```
Graph.hs:68:28: error:
    • Couldn't match type: forall (v :: k -> *). Rec f v a
                     with: Rec f c a
      Expected: Graph f a -> Rec f c a
        Actual: Graph f a -> forall (v :: k -> *). Rec f v a
   |
66 | fold alg k = rfold alg k . unGraph
   |       
   ```
   
   I also tried putting type signature to let GHC 9 know the forall param but failed.
   